### PR TITLE
Feature/oswpq reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ For PyProphet split parquet format (faster, parallelized):
 - `reference_type`: "star" (single reference) or "mst" (minimum spanning tree)
 - `reference_run`: Specific reference run name (null = auto-select)
 - `rt_mapping_tolerance`: RT tolerance in seconds (10.0 recommended)
-- `decoy_peak_mapping_method`: "shuffle" or "random_region"
+- `decoy_peak_mapping_method`: "shuffle" or "random_regions"
 - `compute_scores`: Calculate alignment scores (true recommended)
 
 </details>

--- a/README.md
+++ b/README.md
@@ -21,12 +21,17 @@
 - **Standalone command-line** (`arycal`) executable for:
   - Fast and efficient chromatogram alignment
     - Supports dynamic time warping (DTW), fast Fourier transform (FFT), and a combination of FFT refined by DTW alignment methods
+    - Parallelized with Rayon for optimal performance
   - Scoring quality of alignment
     - Full trace alignment is scored based on cross-correlation coelution score, peak shape similarity and mutual information.
     - Individual peak mapping across runs is scored using the same metrics.
     - A set of decoy aligned peaks is generated (random shuffling of query peak or random region selection) to estimate the quality of peak alignment.
     - If using the IPF OpenSWATH workflow, alignment (based on detecting transitions) and scoring of individual transitions peak mappings is also supported.
-  - Currently only supports output from OpenSWATH (OSW feature files and sqMass XIC files)
+  - Multiple input format support:
+    - **PyProphet split parquet format** (`.oswpqd` directories) - fully parallelized reader
+    - **OSW SQLite format** (`.osw` files)
+    - **sqMass XIC files** and **Parquet XIC files**
+  - Automatic configuration template generation for easy setup
 
 ## Installation
 
@@ -99,79 +104,141 @@ docker pull ghcr.io/singjc/arycal:master
 
 ## Usage
 
-ARYCAL is a command-line tool that uses a json configuration file to specify parameters for the tool. 
+ARYCAL is a command-line tool that uses a json configuration file to specify parameters for the tool.
+
+### Quick Start
+
+If you run ARYCAL without any arguments, it will automatically generate a template configuration file:
 
 ```bash
-# Run ARYCAL 
-arycal arycal_config.json
+# Generate a template configuration file
+arycal
+
+# This creates: arycal_config_template.json
+# Edit the template with your file paths and settings, then run:
+arycal arycal_config_template.json
+```
+
+### Basic Usage
+
+```bash
+# Run ARYCAL with a configuration file
+arycal config.json
+
+# Optionally specify number of threads
+arycal config.json -t 8
 ```
 
 <details>
-<summary> <b>Example Config</b> </summary>
+<summary> <b>Example Configuration</b> </summary>
 
-Remove the comments before running the configuration file.
+### Basic OSW Format (SQLite)
 
 ```json
 {
   "xic": {
-    # Use the precursor chromatogram in the alignment
     "include-precursor": true,
-    # Number of precursor isotopes to use
     "num-isotopes": 3,
-    # The extraction ion chroamtogram input file type (Currently only sqMass is supported)
     "file-type": "sqMass",
-    # The file paths to the XIC files
     "file-paths": [
-      "data/xics/hroest_K120808_Strep0%PlasmaBiolRepl1_R01_SW.sqMass",
-      "data/xics/hroest_K120808_Strep0%PlasmaBiolRepl1_R02_SW.sqMass",
-      "data/xics/hroest_K120808_Strep0%PlasmaBiolRepl1_R03_SW.sqMass"
+      "data/xics/run1.sqMass",
+      "data/xics/run2.sqMass",
+      "data/xics/run3.sqMass"
     ]
   },
   "features": {
-    # The feature file type (Currently only OSW is supported)
     "file-type": "osw",
-    # The file paths to the feature files (Currently only one file is supported, assumming it's a merged OSW file of all runs)
     "file-paths": [
       "data/merged.osw"
     ]
   },
   "filters": {
-    # Whether to include decoy precursor XICs to align as well (false means decoys are included)
-    "decoy": false,
-    # Whether to align and score identifying transitions
+    "include_decoys": false,
     "include_identifying_transitions": false,
-    # A TSV file (with header) to filter for precursor ids to align
-    "precursor_ids": null,
+    "max_score_ms2_qvalue": 1.0,
+    "precursor_ids": null
   },
   "alignment": {
-    # The batch size for aligning N precursors for a given thread
-    "batch_size": 1000,
-    # The alignment method to use (Currently supports DTW, FFT, and FFTDTW)
-    "method": "FFT",
-    # The type of reference to use (Currently supports star, mst, progressive)
+    "batch_size": 10000,
+    "method": "FFTDTW",
     "reference_type": "star",
-    # Specifies the reference run to use (otherwise a random run is selected each time). Only used if reference_type is set to "star"
     "reference_run": null,
-    # Whether to use the total ion chromatogram (TIC) for alignment. (Currently only supports true, as the alignment path is usually monotonic for the MS2 transitions)
     "use_tic": true,
-    # Smoothing parameters for the chromatogram (Currently only supports Savitsky-golay smoothing)
     "smoothing": {
       "sgolay_window": 11,
       "sgolay_order": 3
     },
-    # The tolearance for mapping query peaks to the reference run using the alignment result
-    "rt_mapping_tolerance": 20.0,
-    # The method for generating decoy aligned peaks. (Currently supports shuffle, random_regions)
+    "rt_mapping_tolerance": 10.0,
     "decoy_peak_mapping_method": "shuffle",
-    # Size of the window to use for the decoy peak mapping. Only used when the method is random_region.
     "decoy_window_size": 30,
-    # Compute the scores for the alignment
     "compute_scores": true,
-    # Optionally write out the scores to a separate file (sqlite), otherwise the scores are written to the feature input file
-    "scores_output_file": null
+    "scores_output_file": null,
+    "retain_alignment_path": false
+  },
+  "threads": 8,
+  "log_level": "info"
+}
+```
+
+### PyProphet Parquet Format (OSWPQ)
+
+For PyProphet split parquet format (faster, parallelized):
+
+```json
+{
+  "xic": {
+    "include-precursor": true,
+    "num-isotopes": 3,
+    "file-type": "parquet",
+    "file-paths": [
+      "data/xics/run1.parquet",
+      "data/xics/run2.parquet"
+    ]
+  },
+  "features": {
+    "file-type": "oswpq",
+    "file-paths": [
+      "data/merged_runs.oswpqd"
+    ]
+  },
+  "filters": {
+    "include_decoys": false,
+    "max_score_ms2_qvalue": 0.01
+  },
+  "alignment": {
+    "batch_size": 10000,
+    "method": "FFTDTW",
+    "reference_type": "star"
   }
 }
 ```
+
+### Configuration Fields
+
+**XIC Section:**
+- `include-precursor`: Include precursor chromatograms (true/false)
+- `num-isotopes`: Number of isotopic peaks (typically 3)
+- `file-type`: "sqMass" or "parquet"
+- `file-paths`: List of XIC file paths
+
+**Features Section:**
+- `file-type`: "osw" (SQLite) or "oswpq" (PyProphet split parquet)
+- `file-paths`: Path(s) to feature files
+
+**Filters Section:**
+- `include_decoys`: false = targets only, true = targets + decoys
+- `include_identifying_transitions`: Include non-quantifying transitions
+- `max_score_ms2_qvalue`: Q-value threshold (1.0 = no filtering)
+- `precursor_ids`: Optional TSV file with specific precursor IDs
+
+**Alignment Section:**
+- `batch_size`: Precursors to process per batch (10000 recommended)
+- `method`: "FFT", "DTW", or "FFTDTW" (FFTDTW recommended)
+- `reference_type`: "star" (single reference) or "mst" (minimum spanning tree)
+- `reference_run`: Specific reference run name (null = auto-select)
+- `rt_mapping_tolerance`: RT tolerance in seconds (10.0 recommended)
+- `decoy_peak_mapping_method`: "shuffle" or "random_region"
+- `compute_scores`: Calculate alignment scores (true recommended)
 
 </details>
 

--- a/crates/arycal-cli/src/input.rs
+++ b/crates/arycal-cli/src/input.rs
@@ -142,17 +142,17 @@ impl Input {
         if self.xic.file_type != Some(XicFileType::SqMass) && self.xic.file_type != Some(XicFileType::Parquet) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                "Invalid xic type; expected 'sqMass'",
+                "Invalid xic type; expected 'sqMass' or 'parquet'",
             )
             .into());
         }
 
         // Validate features type
-        if self.features.file_type != Some(FeaturesFileType::OSW) {
+        if self.features.file_type != Some(FeaturesFileType::OSW) && self.features.file_type != Some(FeaturesFileType::OSWPQ) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
-                    "Invalid features type {:?}; expected 'osw'",
+                    "Invalid features type {:?}; expected 'osw' or 'oswpqd'",
                     self.features.file_type
                 ),
             )

--- a/crates/arycal-cli/src/input.rs
+++ b/crates/arycal-cli/src/input.rs
@@ -3,9 +3,9 @@ use clap::ArgMatches;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{self, Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-use arycal_common::config::{AlignmentConfig, FeaturesConfig, FeaturesFileType, FiltersConfig, OpenSwathConfig, PQPConfig, PyProphetConfig, VisualizationConfig, XicConfig, XicFileType};
+use arycal_common::config::{AlignmentConfig, FeaturesConfig, FeaturesFileType, FiltersConfig, XicConfig, XicFileType};
 
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -16,43 +16,19 @@ pub struct Input {
     pub filters: FiltersConfig,
     pub alignment: AlignmentConfig,
     
-    /// GUI only releated fields
-    pub n_concurrent_processes: usize,
-    pub python_path: Option<String>, // Path to Python executable
-    pub last_python_dir: Option<String>,
-
-
     pub threads: usize,
     pub log_level: String,
-    pub arycal_binary_path: Option<PathBuf>,
-    pub pqp: Option<PQPConfig>,
-    pub openswath: Option<OpenSwathConfig>,
-    pub statistical_validation: Option<PyProphetConfig>,
-    pub visualization: Option<VisualizationConfig>, 
 }
 
 impl Default for Input {
     fn default() -> Self {
         Input {
-            // these will just use their own Defaults:
             xic: XicConfig::default(),
             features: FeaturesConfig::default(),
             filters: FiltersConfig::default(),
             alignment: AlignmentConfig::default(),
-
-            // your GUI defaults:
-            n_concurrent_processes: 1,
-            python_path: None,
-            last_python_dir: None,
             threads: std::thread::available_parallelism().unwrap().get().saturating_sub(1).max(1),
             log_level: "info".to_string(),
-
-            // rest can be None or whatever makes sense
-            arycal_binary_path: None,
-            pqp: None,
-            openswath: None,
-            statistical_validation: None,
-            visualization: None,
         }
     }
 }

--- a/crates/arycal-cli/src/lib.rs
+++ b/crates/arycal-cli/src/lib.rs
@@ -190,8 +190,13 @@ impl Runner {
             precursor_ids = Some(load_precursor_ids_from_tsv(precursor_ids_file)?);
         }
 
+        // filter_decoys parameter in fetch_transition_ids: when true, EXCLUDES decoys (only processes targets)
+        // include_decoys config field: when true, INCLUDES decoys (processes both targets and decoys)
+        // So: filter_decoys = !include_decoys
+        let filter_decoys = !parameters.filters.include_decoys;
+        
         let precursor_map: Vec<PrecursorIdData> = feature_accessor.fetch_transition_ids(
-            parameters.filters.decoy, 
+            filter_decoys, 
             parameters.filters.include_identifying_transitions.unwrap_or_default(), 
             precursor_ids
         )?;

--- a/crates/arycal-cli/src/lib.rs
+++ b/crates/arycal-cli/src/lib.rs
@@ -21,10 +21,11 @@ use arycal_cloudpath::{
     ChromatogramReader,
     tsv::load_precursor_ids_from_tsv,
     osw::{OswAccess, PrecursorIdData},
+    oswpq::OswpqAccess,
     sqmass::SqMassAccess,
     xic_parquet::DuckDBParquetChromatogramReader
 };
-use arycal_common::{chromatogram::{create_common_rt_space, AlignedChromatogram}, AlignedTransitionScores, PrecursorXics, AlignedTics, PeakMapping, PrecursorAlignmentResult};
+use arycal_common::{chromatogram::{create_common_rt_space, AlignedChromatogram}, AlignedTransitionScores, PrecursorXics, AlignedTics, PeakMapping, PrecursorAlignmentResult, config::FeaturesFileType};
 use arycal_core::{alignment::alignment::apply_post_alignment_to_trgrp, scoring::{compute_alignment_scores, compute_peak_mapping_scores, compute_peak_mapping_transitions_scores}};
 use arycal_core::{
     alignment::alignment::map_peaks_across_runs,
@@ -34,12 +35,123 @@ use arycal_core::{
     scoring::{create_decoy_peaks_by_random_regions, create_decoy_peaks_by_shuffling},
 };
 use arycal_cloudpath::osw::FeatureData;
-use input::Input; 
+use input::Input;
+
+/// Enum to handle both OSW and OSWPQ feature accessors
+pub enum FeatureAccessor {
+    Osw(OswAccess),
+    Oswpq(OswpqAccess),
+}
+
+impl FeatureAccessor {
+    fn fetch_transition_ids(
+        &self,
+        filter_decoys: bool,
+        include_identifying: bool,
+        precursor_ids: Option<Vec<u32>>,
+    ) -> anyhow::Result<Vec<PrecursorIdData>> {
+        match self {
+            FeatureAccessor::Osw(access) => {
+                access.fetch_transition_ids(filter_decoys, include_identifying, precursor_ids)
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+            FeatureAccessor::Oswpq(access) => {
+                access.fetch_transition_ids(filter_decoys, include_identifying, precursor_ids)
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+        }
+    }
+
+    fn fetch_feature_data_for_precursor_batch(
+        &self,
+        precursor_run_sets: &[(i32, Vec<String>)],
+    ) -> anyhow::Result<HashMap<i32, Vec<FeatureData>>> {
+        match self {
+            FeatureAccessor::Osw(access) => {
+                access.fetch_feature_data_for_precursor_batch(precursor_run_sets)
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+            FeatureAccessor::Oswpq(access) => {
+                access.fetch_feature_data_for_precursor_batch(precursor_run_sets)
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+        }
+    }
+
+    fn fetch_full_precursor_feature_data_for_runs(
+        &self,
+        precursor_id: i32,
+        runs: Vec<String>,
+    ) -> anyhow::Result<Vec<FeatureData>> {
+        match self {
+            FeatureAccessor::Osw(access) => {
+                access.fetch_full_precursor_feature_data_for_runs(precursor_id, runs)
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+            FeatureAccessor::Oswpq(access) => {
+                access.fetch_full_precursor_feature_data_for_runs(precursor_id, runs)
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+        }
+    }
+
+    fn create_feature_ms2_alignment_table(&self) -> anyhow::Result<()> {
+        match self {
+            FeatureAccessor::Osw(access) => {
+                access.create_feature_ms2_alignment_table()
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+            FeatureAccessor::Oswpq(access) => {
+                access.create_feature_ms2_alignment_table()
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+        }
+    }
+
+    fn create_feature_transition_alignment_table(&self) -> anyhow::Result<()> {
+        match self {
+            FeatureAccessor::Osw(access) => {
+                access.create_feature_transition_alignment_table()
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+            FeatureAccessor::Oswpq(access) => {
+                access.create_feature_transition_alignment_table()
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+        }
+    }
+
+    fn insert_feature_ms2_alignment_batch(&self, peak_mappings: &[PeakMapping]) -> anyhow::Result<()> {
+        match self {
+            FeatureAccessor::Osw(access) => {
+                access.insert_feature_ms2_alignment_batch(peak_mappings)
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+            FeatureAccessor::Oswpq(access) => {
+                access.write_ms2_alignment_batch(peak_mappings)
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+        }
+    }
+
+    fn insert_feature_transition_alignment_batch(&self, transition_scores: &[AlignedTransitionScores]) -> anyhow::Result<()> {
+        match self {
+            FeatureAccessor::Osw(access) => {
+                access.insert_feature_transition_alignment_batch(transition_scores)
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+            FeatureAccessor::Oswpq(access) => {
+                access.write_transition_alignment_batch(transition_scores)
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+        }
+    }
+}
 
 pub struct Runner {
     precursor_map: Vec<PrecursorIdData>,
     parameters: input::Input,
-    feature_access: Vec<OswAccess>,
+    feature_access: Vec<FeatureAccessor>,
     xic_access: Vec<Box<dyn ChromatogramReader>>,
     start: Instant
 }
@@ -48,9 +160,29 @@ impl Runner {
     pub fn new(parameters: Input) -> anyhow::Result<Self> {
         let start = Instant::now();
 
-        // TODO: Currently only supports a single OSW file
+        // Determine the feature file type
+        let feature_file_type = parameters.features.file_type.clone()
+            .unwrap_or(FeaturesFileType::OSW);
+        
+        log::info!("Using feature file type: {:?}", feature_file_type);
+
+        // TODO: Currently only supports a single feature file
         let start_io = Instant::now();
-        let osw_access = OswAccess::new(&parameters.features.file_paths[0].to_str().unwrap(), true)?;
+        let feature_accessor = match feature_file_type {
+            FeaturesFileType::OSW => {
+                log::info!("Loading OSW file: {:?}", parameters.features.file_paths[0]);
+                let osw_access = OswAccess::new(&parameters.features.file_paths[0].to_str().unwrap(), true)?;
+                FeatureAccessor::Osw(osw_access)
+            },
+            FeaturesFileType::OSWPQ => {
+                log::info!("Loading OSWPQ directory: {:?}", parameters.features.file_paths[0]);
+                let oswpq_access = OswpqAccess::new(&parameters.features.file_paths[0])?;
+                FeatureAccessor::Oswpq(oswpq_access)
+            },
+            FeaturesFileType::Unknown => {
+                return Err(anyhow::anyhow!("Unknown feature file type"));
+            }
+        };
 
         // Check if precursor_ids tsv file is provided
         let mut precursor_ids: Option<Vec<u32>> = None;
@@ -58,7 +190,11 @@ impl Runner {
             precursor_ids = Some(load_precursor_ids_from_tsv(precursor_ids_file)?);
         }
 
-        let precursor_map: Vec<PrecursorIdData> = osw_access.fetch_transition_ids(parameters.filters.decoy, parameters.filters.include_identifying_transitions.unwrap_or_default(), precursor_ids)?;
+        let precursor_map: Vec<PrecursorIdData> = feature_accessor.fetch_transition_ids(
+            parameters.filters.decoy, 
+            parameters.filters.include_identifying_transitions.unwrap_or_default(), 
+            precursor_ids
+        )?;
         let run_time = (Instant::now() - start_io).as_millis();
 
         info!(
@@ -92,7 +228,7 @@ impl Runner {
         Ok(Self {
             precursor_map: precursor_map.clone(),
             parameters,
-            feature_access: vec![osw_access],
+            feature_access: vec![feature_accessor],
             xic_access: xic_accessors,
             start
         })
@@ -123,12 +259,24 @@ impl Runner {
     
         log::info!("Starting alignment for {} precursors", total_count);
     
-        let feature_access = if let Some(scores_output_file) = &self.parameters.alignment.scores_output_file {
+        let separate_output_accessor: Option<FeatureAccessor>;
+        let feature_access: &[FeatureAccessor] = if let Some(scores_output_file) = &self.parameters.alignment.scores_output_file {
             let scores_output_file = scores_output_file.clone();
-            let osw_access = OswAccess::new(&scores_output_file, false)?;
-            vec![osw_access]
+            // Check file extension to determine type
+            let accessor = if scores_output_file.ends_with(".oswpqd") || scores_output_file.ends_with(".oswpq") {
+                log::info!("Creating separate OSWPQ output: {}", scores_output_file);
+                let oswpq_access = OswpqAccess::new(&scores_output_file)?;
+                FeatureAccessor::Oswpq(oswpq_access)
+            } else {
+                log::info!("Creating separate OSW output: {}", scores_output_file);
+                let osw_access = OswAccess::new(&scores_output_file, false)?;
+                FeatureAccessor::Osw(osw_access)
+            };
+            separate_output_accessor = Some(accessor);
+            std::slice::from_ref(separate_output_accessor.as_ref().unwrap())
         } else {
-            self.feature_access.clone()
+            separate_output_accessor = None;
+            &self.feature_access
         };
 
         // Initialize writers if they don't exist or drop them if they do
@@ -138,13 +286,13 @@ impl Runner {
         //     }
         // }
 
-        for osw_access in &feature_access {
-            osw_access.create_feature_ms2_alignment_table()?;
+        for accessor in feature_access {
+            accessor.create_feature_ms2_alignment_table()?;
         }
 
         if self.parameters.filters.include_identifying_transitions.unwrap_or_default() && self.parameters.alignment.compute_scores.unwrap_or_default() {
-            for osw_access in &feature_access {
-                osw_access.create_feature_transition_alignment_table()?;
+            for accessor in feature_access {
+                accessor.create_feature_transition_alignment_table()?;
             }
         }
     
@@ -1053,7 +1201,7 @@ impl Runner {
 
     fn write_ms2_alignment_results_to_db(
         &self,
-        feature_access: &[OswAccess],
+        feature_access: &[FeatureAccessor],
         results: &HashMap<i32, PrecursorAlignmentResult>,
     ) -> Result<()> {
         // Collect all MS2 alignment results
@@ -1066,12 +1214,12 @@ impl Runner {
     
         // Write all alignments to each database
         if !all_ms2_alignments.is_empty() {
-            for osw_access in feature_access {
+            for accessor in feature_access {
                 log::debug!(
                     "Inserting {} MS2 aligned features",
                     all_ms2_alignments.len()
                 );
-                osw_access.insert_feature_ms2_alignment_batch(&all_ms2_alignments)?;
+                accessor.insert_feature_ms2_alignment_batch(&all_ms2_alignments)?;
             }
         } else {
             log::warn!("No MS2 aligned features to write to the database");
@@ -1082,7 +1230,7 @@ impl Runner {
 
     fn write_transition_alignment_results_to_db(
         &self,
-        feature_access: &[OswAccess],
+        feature_access: &[FeatureAccessor],
         results: &HashMap<i32, PrecursorAlignmentResult>,
     ) -> Result<()> {
         // Collect all transition alignment results
@@ -1096,12 +1244,12 @@ impl Runner {
     
         // Write all transition alignments to each database
         if !all_transition_alignments.is_empty() {
-            for osw_access in feature_access {
+            for accessor in feature_access {
                 log::debug!(
                     "Inserting {} transition aligned features",
                     all_transition_alignments.len()
                 );
-                osw_access.insert_feature_transition_alignment_batch(&all_transition_alignments)?;
+                accessor.insert_feature_transition_alignment_batch(&all_transition_alignments)?;
             }
         }
     

--- a/crates/arycal-cli/src/main.rs
+++ b/crates/arycal-cli/src/main.rs
@@ -5,8 +5,101 @@ use clap::{Arg, Command, ValueHint};
 use anyhow::Result;
 use arycal_cli::input::Input; 
 use arycal_cli::Runner;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
 #[cfg(not(target_os = "windows"))]
 use rlimit::{Resource, setrlimit};
+use arycal_common::config::{AlignmentConfig, FeaturesConfig, FiltersConfig, XicConfig};
+
+fn generate_config_template(path: &str) -> Result<()> {
+    // Create a default Input with only core alignment fields
+    let template_config = Input {
+        xic: XicConfig::default(),
+        features: FeaturesConfig::default(),
+        filters: FiltersConfig::default(),
+        alignment: AlignmentConfig::default(),
+        threads: std::thread::available_parallelism().unwrap().get().saturating_sub(1).max(1),
+        log_level: "info".to_string(),
+    };
+
+    // Serialize to pretty JSON
+    let json = serde_json::to_string_pretty(&template_config)?;
+    
+    // Create documentation to append
+    let docs = r#"
+
+# Configuration Guide:
+#
+# NOTE: Remove comments (lines starting with #) before using this file as a configuration.
+# 
+# XIC Section:
+#   - include-precursor: Include precursor chromatograms (true/false)
+#   - num-isotopes: Number of isotopic peaks to include (typically 3)
+#   - file-type: "sqMass" for SQLite-based XICs or "parquet" for Parquet-based XICs
+#   - file-paths: List of paths to your XIC files
+#
+# Features Section:
+#   - file-type: "osw" for SQLite features or "oswpq" for PyProphet split parquet format
+#   - file-paths: Path to your features file (merged.osw or merged_runs.oswpqd directory)
+#
+# Filters Section:
+#   - include_decoys: false = only align targets, true = align both targets and decoys
+#   - include_identifying_transitions: Include non-quantifying transitions (default: false)
+#   - max_score_ms2_qvalue: Maximum q-value threshold for filtering (1.0 = no filtering)
+#   - precursor_ids: Optional path to TSV file with specific precursor IDs to process
+#
+# Alignment Section:
+#   - batch_size: Number of precursors to process before writing results (10000 recommended)
+#   - method: Alignment method - "FFT", "DTW", or "FFTDTW" (FFTDTW recommended)
+#   - reference_type: "star" (align to one reference) or "mst" (minimum spanning tree)
+#   - reference_run: Specific run to use as reference (null = auto-select)
+#   - use_tic: Use total ion chromatogram for alignment (always true)
+#   - smoothing: Savitzky-Golay filter parameters
+#     * sgolay_window: Window size (must be odd, typically 11)
+#     * sgolay_order: Polynomial order (typically 3)
+#   - rt_mapping_tolerance: Retention time tolerance in seconds for peak mapping (10.0 recommended)
+#   - decoy_peak_mapping_method: "shuffle" or "random_region"
+#   - decoy_window_size: Window size for random_region method
+#   - compute_scores: Calculate alignment scores (true recommended)
+#   - scores_output_file: Write scores to separate file (null = write to input file)
+#   - retain_alignment_path: Keep alignment path data (needed for identifying transitions)
+#
+# Threads & Logging:
+#   - threads: Number of threads to use (default = # of CPUs - 1)
+#   - log_level: Log verbosity ("error", "warn", "info", "debug", "trace")
+#
+# Example configurations:
+#
+# For PyProphet parquet format:
+#   "features": {
+#     "file-type": "oswpq",
+#     "file-paths": ["/path/to/merged_runs.oswpqd"]
+#   }
+#
+# For parquet XICs:
+#   "xic": {
+#     "file-type": "parquet",
+#     "file-paths": ["/path/to/file1.parquet", "/path/to/file2.parquet"]
+#   }
+#
+# To filter for specific precursors:
+#   "filters": {
+#     "precursor_ids": "/path/to/precursor_list.tsv"
+#   }
+#
+# To use a specific run as reference:
+#   "alignment": {
+#     "reference_type": "star",
+#     "reference_run": "your_run_name"
+#   }
+"#;
+
+    let mut file = File::create(path)?;
+    file.write_all(json.as_bytes())?;
+    file.write_all(docs.as_bytes())?;
+    Ok(())
+}
 
 fn increase_limits() -> Result<(), anyhow::Error> {
     #[cfg(not(target_os = "windows"))]
@@ -39,7 +132,7 @@ fn main() -> Result<()> {
         .about("\u{1F52E} Arycal \u{1F9D9} - Across Run Dynamic Chromatogram Alignment")
         .arg(
             Arg::new("parameters")
-                .required(true)
+                .required(false)  // Changed to optional
                 .value_parser(clap::builder::NonEmptyStringValueParser::new())
                 .help("Path to configuration parameters (JSON file)")
                 .value_hint(ValueHint::FilePath),
@@ -68,6 +161,30 @@ fn main() -> Result<()> {
              {all-args}{after-help}",
         )
         .get_matches();
+
+    // Check if config file was provided
+    if matches.get_one::<String>("parameters").is_none() {
+        // Generate template config file
+        let template_path = "arycal_config_template.json";
+        
+        match generate_config_template(template_path) {
+            Ok(_) => {
+                eprintln!("\n\u{274C} Error: No configuration file provided!");
+                eprintln!("\n\u{2728} A template configuration file has been generated: {}", template_path);
+                eprintln!("\nTo use arycal:");
+                eprintln!("  1. Edit '{}' with your file paths and settings", template_path);
+                eprintln!("  2. Run: arycal {}", template_path);
+                eprintln!("\nFor more information, see the documentation or run: arycal --help\n");
+                std::process::exit(1);
+            }
+            Err(e) => {
+                eprintln!("\n\u{274C} Error: No configuration file provided!");
+                eprintln!("Failed to generate template: {}", e);
+                eprintln!("\nUsage: arycal <config.json>\n");
+                std::process::exit(1);
+            }
+        }
+    }
 
     // Load parameters from JSON file
     let input = Input::from_arguments(&matches)?;

--- a/crates/arycal-cli/src/main.rs
+++ b/crates/arycal-cli/src/main.rs
@@ -59,8 +59,8 @@ fn generate_config_template(path: &str) -> Result<()> {
 #     * sgolay_window: Window size (must be odd, typically 11)
 #     * sgolay_order: Polynomial order (typically 3)
 #   - rt_mapping_tolerance: Retention time tolerance in seconds for peak mapping (10.0 recommended)
-#   - decoy_peak_mapping_method: "shuffle" or "random_region"
-#   - decoy_window_size: Window size for random_region method
+#   - decoy_peak_mapping_method: "shuffle" or "random_regions"
+#   - decoy_window_size: Window size for random_regions method
 #   - compute_scores: Calculate alignment scores (true recommended)
 #   - scores_output_file: Write scores to separate file (null = write to input file)
 #   - retain_alignment_path: Keep alignment path data (needed for identifying transitions)

--- a/crates/arycal-cloudpath/src/lib.rs
+++ b/crates/arycal-cloudpath/src/lib.rs
@@ -10,6 +10,7 @@ use sqmass::TransitionGroup;
 // Import necessary modules and dependencies
 pub mod tsv;
 pub mod osw;
+pub mod oswpq;
 pub mod sqmass;
 pub mod compression;
 pub mod util;

--- a/crates/arycal-cloudpath/src/oswpq.rs
+++ b/crates/arycal-cloudpath/src/oswpq.rs
@@ -129,9 +129,52 @@ impl OswpqAccess {
             ));
         }
 
-        Ok(Self {
+        let instance = Self {
             base_path,
-        })
+        };
+
+        // Backup any existing output files from previous runs
+        instance.backup_existing_output_files()?;
+
+        Ok(instance)
+    }
+
+    /// Backup existing output files from previous runs
+    /// 
+    /// This prevents appending new results to old results from a different run.
+    /// Only appends should happen within the same running instance of arycal.
+    fn backup_existing_output_files(&self) -> Result<(), OpenSwathParquetError> {
+        use std::time::SystemTime;
+        
+        let output_files = [
+            "feature_alignment.parquet",
+            "feature_ms2_alignment.parquet",
+            "feature_transition_alignment.parquet",
+        ];
+
+        let timestamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        for filename in &output_files {
+            let file_path = self.base_path.join(filename);
+            
+            if file_path.exists() {
+                let backup_path = self.base_path.join(format!("{}.old.{}", filename, timestamp));
+                
+                std::fs::rename(&file_path, &backup_path)
+                    .map_err(|e| OpenSwathParquetError::IoError(e.to_string()))?;
+                
+                log::info!(
+                    "Backed up existing {} to {}",
+                    filename,
+                    backup_path.display()
+                );
+            }
+        }
+
+        Ok(())
     }
 
     /// Convert PeakMapping to AlignmentFeature for PyProphet format

--- a/crates/arycal-cloudpath/src/oswpq.rs
+++ b/crates/arycal-cloudpath/src/oswpq.rs
@@ -154,7 +154,7 @@ impl OswpqAccess {
 
         let timestamp = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
+            .map_err(|e| OpenSwathParquetError::IoError(format!("System time error: {}", e)))?
             .as_secs();
 
         for filename in &output_files {

--- a/crates/arycal-cloudpath/src/oswpq.rs
+++ b/crates/arycal-cloudpath/src/oswpq.rs
@@ -165,15 +165,29 @@ impl OswpqAccess {
 
     /// Get the path to a specific run's precursors_features.parquet file
     pub fn get_precursors_features_path(&self, run_name: &str) -> PathBuf {
+        // Handle both cases: with or without .oswpq extension
+        let dir_name = if run_name.ends_with(".oswpq") {
+            run_name.to_string()
+        } else {
+            format!("{}.oswpq", run_name)
+        };
+        
         self.base_path
-            .join(run_name)
+            .join(dir_name)
             .join("precursors_features.parquet")
     }
 
     /// Get the path to a specific run's transition_features.parquet file
     pub fn get_transition_features_path(&self, run_name: &str) -> PathBuf {
+        // Handle both cases: with or without .oswpq extension
+        let dir_name = if run_name.ends_with(".oswpq") {
+            run_name.to_string()
+        } else {
+            format!("{}.oswpq", run_name)
+        };
+        
         self.base_path
-            .join(run_name)
+            .join(dir_name)
             .join("transition_features.parquet")
     }
 

--- a/crates/arycal-cloudpath/src/oswpq.rs
+++ b/crates/arycal-cloudpath/src/oswpq.rs
@@ -133,6 +133,28 @@ impl OswpqAccess {
         })
     }
 
+    /// Convert PeakMapping to AlignmentFeature for PyProphet format
+    fn peak_mapping_to_alignment_feature(pm: &PeakMapping) -> AlignmentFeature {
+        AlignmentFeature {
+            alignment_id: pm.alignment_id,
+            run_id: pm.run_id,
+            precursor_id: pm.precursor_id as i64,
+            feature_id: pm.aligned_feature_id,
+            reference_feature_id: pm.reference_feature_id,
+            aligned_rt: pm.aligned_rt,
+            reference_rt: pm.reference_rt,
+            var_xcorr_coelution_to_reference: pm.xcorr_coelution_to_ref,
+            var_xcorr_shape_to_reference: pm.xcorr_shape_to_ref,
+            var_mi_to_reference: pm.mi_to_ref,
+            var_xcorr_coelution_to_all: pm.xcorr_coelution_to_all,
+            var_xcorr_shape: pm.xcorr_shape_to_all,
+            var_mi_to_all: pm.mi_to_all,
+            var_retention_time_deviation: pm.rt_deviation,
+            var_peak_intensity_ratio: pm.intensity_ratio,
+            decoy: pm.label as i64,
+        }
+    }
+
     /// Create a DuckDB connection for querying
     fn create_connection(&self) -> Result<Connection, OpenSwathParquetError> {
         Connection::open_in_memory()
@@ -635,6 +657,7 @@ impl OswpqAccess {
     }
 
     /// Write MS2 alignment batch to parquet file
+    /// This writes in PyProphet's expected format (feature_alignment.parquet)
     pub fn write_ms2_alignment_batch(
         &self,
         peak_mappings: &[PeakMapping],
@@ -643,7 +666,34 @@ impl OswpqAccess {
             return Ok(());
         }
 
-        let output_path = self.base_path.join("feature_ms2_alignment.parquet");
+        // Convert PeakMapping to AlignmentFeature format
+        let alignment_features: Vec<AlignmentFeature> = peak_mappings
+            .iter()
+            .map(Self::peak_mapping_to_alignment_feature)
+            .collect();
+
+        // Write using PyProphet format
+        self.write_alignment_features(&alignment_features)?;
+
+        // Optionally write the detailed format with additional fields
+        // Uncomment if you want both formats:
+        // self.write_ms2_alignment_detailed(peak_mappings)?;
+
+        Ok(())
+    }
+
+    /// Write MS2 alignment batch to parquet file (detailed format with all PeakMapping fields)
+    /// This is an optional extra output format that includes additional fields not in PyProphet format
+    #[allow(dead_code)]
+    pub fn write_ms2_alignment_detailed(
+        &self,
+        peak_mappings: &[PeakMapping],
+    ) -> Result<(), OpenSwathParquetError> {
+        if peak_mappings.is_empty() {
+            return Ok(());
+        }
+
+        let output_path = self.base_path.join("feature_ms2_alignment_detailed.parquet");
         let conn = self.create_connection()?;
 
         // Create temporary table

--- a/crates/arycal-cloudpath/src/oswpq.rs
+++ b/crates/arycal-cloudpath/src/oswpq.rs
@@ -21,6 +21,7 @@ use std::fs;
 use std::fmt;
 use std::error::Error;
 use std::collections::HashMap;
+use rayon::prelude::*;
 
 // Import types from the osw module that we need
 use crate::osw::{PrecursorIdData, FeatureData, ValueEntryType};
@@ -381,29 +382,31 @@ impl OswpqAccess {
         // Insert features in batches
         let batch_size = 1000;
         for chunk in features.chunks(batch_size) {
-            let mut values = Vec::new();
-            
-            for feature in chunk {
-                values.push(format!(
-                    "({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {})",
-                    feature.alignment_id,
-                    feature.run_id,
-                    feature.precursor_id,
-                    feature.feature_id,
-                    feature.reference_feature_id,
-                    feature.aligned_rt,
-                    feature.reference_rt,
-                    feature.var_xcorr_coelution_to_reference.map_or("NULL".to_string(), |v| v.to_string()),
-                    feature.var_xcorr_shape_to_reference.map_or("NULL".to_string(), |v| v.to_string()),
-                    feature.var_mi_to_reference.map_or("NULL".to_string(), |v| v.to_string()),
-                    feature.var_xcorr_coelution_to_all.map_or("NULL".to_string(), |v| v.to_string()),
-                    feature.var_xcorr_shape.map_or("NULL".to_string(), |v| v.to_string()),
-                    feature.var_mi_to_all.map_or("NULL".to_string(), |v| v.to_string()),
-                    feature.var_retention_time_deviation.map_or("NULL".to_string(), |v| v.to_string()),
-                    feature.var_peak_intensity_ratio.map_or("NULL".to_string(), |v| v.to_string()),
-                    feature.decoy,
-                ));
-            }
+            // Format values in parallel for better performance with large batches
+            let values: Vec<String> = chunk
+                .par_iter()
+                .map(|feature| {
+                    format!(
+                        "({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {})",
+                        feature.alignment_id,
+                        feature.run_id,
+                        feature.precursor_id,
+                        feature.feature_id,
+                        feature.reference_feature_id,
+                        feature.aligned_rt,
+                        feature.reference_rt,
+                        feature.var_xcorr_coelution_to_reference.map_or("NULL".to_string(), |v| v.to_string()),
+                        feature.var_xcorr_shape_to_reference.map_or("NULL".to_string(), |v| v.to_string()),
+                        feature.var_mi_to_reference.map_or("NULL".to_string(), |v| v.to_string()),
+                        feature.var_xcorr_coelution_to_all.map_or("NULL".to_string(), |v| v.to_string()),
+                        feature.var_xcorr_shape.map_or("NULL".to_string(), |v| v.to_string()),
+                        feature.var_mi_to_all.map_or("NULL".to_string(), |v| v.to_string()),
+                        feature.var_retention_time_deviation.map_or("NULL".to_string(), |v| v.to_string()),
+                        feature.var_peak_intensity_ratio.map_or("NULL".to_string(), |v| v.to_string()),
+                        feature.decoy,
+                    )
+                })
+                .collect();
 
             let insert_query = format!(
                 "INSERT INTO alignment_temp VALUES {}",
@@ -415,18 +418,27 @@ impl OswpqAccess {
                 .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
         }
 
-        // Export to parquet
-        let export_query = format!(
-            "COPY alignment_temp TO '{}' (FORMAT PARQUET)",
-            output_path.display()
-        );
+        // Export to parquet (append mode if file exists)
+        let export_query = if output_path.exists() {
+            // Read existing data, union with new data, and overwrite
+            format!(
+                "COPY (SELECT * FROM read_parquet('{}') UNION ALL SELECT * FROM alignment_temp) TO '{}' (FORMAT PARQUET)",
+                output_path.display(),
+                output_path.display()
+            )
+        } else {
+            format!(
+                "COPY alignment_temp TO '{}' (FORMAT PARQUET)",
+                output_path.display()
+            )
+        };
 
         conn
             .execute(&export_query, [])
             .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
 
         log::info!(
-            "Wrote {} alignment features to {}",
+            "Wrote {} alignment features to {} (appending to existing data)",
             features.len(),
             output_path.display()
         );
@@ -625,18 +637,23 @@ impl OswpqAccess {
     }
 
     /// Fetch feature data for a batch of precursors
+    /// This method processes precursors in parallel for better performance
     pub fn fetch_feature_data_for_precursor_batch(
         &self,
         precursor_run_sets: &[(i32, Vec<String>)],
     ) -> Result<HashMap<i32, Vec<FeatureData>>, OpenSwathParquetError> {
-        let conn = self.create_connection()?;
-        let mut result_map: HashMap<i32, Vec<FeatureData>> = HashMap::new();
+        // Process precursors in parallel
+        // Each thread creates its own connection since DuckDB connections are not thread-safe
+        let results: Result<Vec<_>, OpenSwathParquetError> = precursor_run_sets
+            .par_iter()
+            .map(|(precursor_id, runs)| {
+                let feature_data = self.fetch_full_precursor_feature_data_for_runs(*precursor_id, runs.clone())?;
+                Ok((*precursor_id, feature_data))
+            })
+            .collect();
 
-        // Process each precursor
-        for (precursor_id, runs) in precursor_run_sets {
-            let feature_data = self.fetch_full_precursor_feature_data_for_runs(*precursor_id, runs.clone())?;
-            result_map.insert(*precursor_id, feature_data);
-        }
+        // Convert Vec of results into HashMap
+        let result_map: HashMap<i32, Vec<FeatureData>> = results?.into_iter().collect();
 
         Ok(result_map)
     }
@@ -666,9 +683,9 @@ impl OswpqAccess {
             return Ok(());
         }
 
-        // Convert PeakMapping to AlignmentFeature format
+        // Convert PeakMapping to AlignmentFeature format in parallel
         let alignment_features: Vec<AlignmentFeature> = peak_mappings
-            .iter()
+            .par_iter()
             .map(Self::peak_mapping_to_alignment_feature)
             .collect();
 
@@ -730,35 +747,37 @@ impl OswpqAccess {
         // Insert data in batches
         let batch_size = 1000;
         for chunk in peak_mappings.chunks(batch_size) {
-            let mut values = Vec::new();
-            
-            for pm in chunk {
-                values.push(format!(
-                    "({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, '{}', '{}', {}, {}, {}, {}, {}, {}, {}, {}, {})",
-                    pm.alignment_id,
-                    pm.precursor_id,
-                    pm.run_id,
-                    pm.reference_feature_id,
-                    pm.aligned_feature_id,
-                    pm.reference_rt,
-                    pm.aligned_rt,
-                    pm.reference_left_width,
-                    pm.reference_right_width,
-                    pm.aligned_left_width,
-                    pm.aligned_right_width,
-                    pm.reference_filename.replace("'", "''"),
-                    pm.aligned_filename.replace("'", "''"),
-                    pm.xcorr_coelution_to_ref.map_or("NULL".to_string(), |v| v.to_string()),
-                    pm.xcorr_shape_to_ref.map_or("NULL".to_string(), |v| v.to_string()),
-                    pm.mi_to_ref.map_or("NULL".to_string(), |v| v.to_string()),
-                    pm.xcorr_coelution_to_all.map_or("NULL".to_string(), |v| v.to_string()),
-                    pm.xcorr_shape_to_all.map_or("NULL".to_string(), |v| v.to_string()),
-                    pm.mi_to_all.map_or("NULL".to_string(), |v| v.to_string()),
-                    pm.rt_deviation.map_or("NULL".to_string(), |v| v.to_string()),
-                    pm.intensity_ratio.map_or("NULL".to_string(), |v| v.to_string()),
-                    pm.label,
-                ));
-            }
+            // Format values in parallel for better performance with large batches
+            let values: Vec<String> = chunk
+                .par_iter()
+                .map(|pm| {
+                    format!(
+                        "({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, '{}', '{}', {}, {}, {}, {}, {}, {}, {}, {}, {})",
+                        pm.alignment_id,
+                        pm.precursor_id,
+                        pm.run_id,
+                        pm.reference_feature_id,
+                        pm.aligned_feature_id,
+                        pm.reference_rt,
+                        pm.aligned_rt,
+                        pm.reference_left_width,
+                        pm.reference_right_width,
+                        pm.aligned_left_width,
+                        pm.aligned_right_width,
+                        pm.reference_filename.replace("'", "''"),
+                        pm.aligned_filename.replace("'", "''"),
+                        pm.xcorr_coelution_to_ref.map_or("NULL".to_string(), |v| v.to_string()),
+                        pm.xcorr_shape_to_ref.map_or("NULL".to_string(), |v| v.to_string()),
+                        pm.mi_to_ref.map_or("NULL".to_string(), |v| v.to_string()),
+                        pm.xcorr_coelution_to_all.map_or("NULL".to_string(), |v| v.to_string()),
+                        pm.xcorr_shape_to_all.map_or("NULL".to_string(), |v| v.to_string()),
+                        pm.mi_to_all.map_or("NULL".to_string(), |v| v.to_string()),
+                        pm.rt_deviation.map_or("NULL".to_string(), |v| v.to_string()),
+                        pm.intensity_ratio.map_or("NULL".to_string(), |v| v.to_string()),
+                        pm.label,
+                    )
+                })
+                .collect();
 
             let insert_query = format!(
                 "INSERT INTO ms2_alignment_temp VALUES {}",
@@ -833,26 +852,28 @@ impl OswpqAccess {
         // Insert data in batches
         let batch_size = 1000;
         for chunk in transition_scores.chunks(batch_size) {
-            let mut values = Vec::new();
-            
-            for ts in chunk {
-                values.push(format!(
-                    "({}, {}, {}, '{}', {}, {}, {}, {}, {}, {}, {}, {}, {})",
-                    ts.feature_id,
-                    ts.transition_id,
-                    ts.run_id,
-                    ts.aligned_filename.replace("'", "''"),
-                    ts.label,
-                    ts.xcorr_coelution_to_ref.map_or("NULL".to_string(), |v| v.to_string()),
-                    ts.xcorr_shape_to_ref.map_or("NULL".to_string(), |v| v.to_string()),
-                    ts.mi_to_ref.map_or("NULL".to_string(), |v| v.to_string()),
-                    ts.xcorr_coelution_to_all.map_or("NULL".to_string(), |v| v.to_string()),
-                    ts.xcorr_shape_to_all.map_or("NULL".to_string(), |v| v.to_string()),
-                    ts.mi_to_all.map_or("NULL".to_string(), |v| v.to_string()),
-                    ts.rt_deviation.map_or("NULL".to_string(), |v| v.to_string()),
-                    ts.intensity_ratio.map_or("NULL".to_string(), |v| v.to_string()),
-                ));
-            }
+            // Format values in parallel for better performance with large batches
+            let values: Vec<String> = chunk
+                .par_iter()
+                .map(|ts| {
+                    format!(
+                        "({}, {}, {}, '{}', {}, {}, {}, {}, {}, {}, {}, {}, {})",
+                        ts.feature_id,
+                        ts.transition_id,
+                        ts.run_id,
+                        ts.aligned_filename.replace("'", "''"),
+                        ts.label,
+                        ts.xcorr_coelution_to_ref.map_or("NULL".to_string(), |v| v.to_string()),
+                        ts.xcorr_shape_to_ref.map_or("NULL".to_string(), |v| v.to_string()),
+                        ts.mi_to_ref.map_or("NULL".to_string(), |v| v.to_string()),
+                        ts.xcorr_coelution_to_all.map_or("NULL".to_string(), |v| v.to_string()),
+                        ts.xcorr_shape_to_all.map_or("NULL".to_string(), |v| v.to_string()),
+                        ts.mi_to_all.map_or("NULL".to_string(), |v| v.to_string()),
+                        ts.rt_deviation.map_or("NULL".to_string(), |v| v.to_string()),
+                        ts.intensity_ratio.map_or("NULL".to_string(), |v| v.to_string()),
+                    )
+                })
+                .collect();
 
             let insert_query = format!(
                 "INSERT INTO transition_alignment_temp VALUES {}",

--- a/crates/arycal-cloudpath/src/oswpq.rs
+++ b/crates/arycal-cloudpath/src/oswpq.rs
@@ -1,0 +1,845 @@
+//! PyProphet Split Parquet Format (OSWPQ/OSWPQD) Reader
+//!
+//! This module provides functionality to read PyProphet's split parquet format,
+//! which stores features and scores in parquet files instead of SQLite.
+//!
+//! Structure:
+//! ```
+//! merged_runs.oswpqd/
+//!   ├── run1.oswpq/
+//!   │   ├── precursors_features.parquet
+//!   │   └── transition_features.parquet
+//!   ├── run2.oswpq/
+//!   │   ├── precursors_features.parquet
+//!   │   └── transition_features.parquet
+//!   └── ...
+//! ```
+
+use duckdb::{Connection, Result as DuckDbResult};
+use std::path::{Path, PathBuf};
+use std::fs;
+use std::fmt;
+use std::error::Error;
+use std::collections::HashMap;
+
+// Import types from the osw module that we need
+use crate::osw::{PrecursorIdData, FeatureData, ValueEntryType};
+// Import from arycal_common for PeakMapping and AlignedTransitionScores
+use arycal_common::{PeakMapping, AlignedTransitionScores};
+
+/// Custom error type for OSWPQ operations
+#[derive(Debug)]
+pub enum OpenSwathParquetError {
+    DatabaseError(String),
+    FileNotFound(String),
+    InvalidFormat(String),
+    IoError(String),
+}
+
+impl fmt::Display for OpenSwathParquetError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OpenSwathParquetError::DatabaseError(msg) => write!(f, "[OpenSwathParquetError] Database Error: {}", msg),
+            OpenSwathParquetError::FileNotFound(msg) => write!(f, "[OpenSwathParquetError] File Not Found: {}", msg),
+            OpenSwathParquetError::InvalidFormat(msg) => write!(f, "[OpenSwathParquetError] Invalid Format: {}", msg),
+            OpenSwathParquetError::IoError(msg) => write!(f, "[OpenSwathParquetError] IO Error: {}", msg),
+        }
+    }
+}
+
+impl Error for OpenSwathParquetError {}
+
+impl From<duckdb::Error> for OpenSwathParquetError {
+    fn from(err: duckdb::Error) -> OpenSwathParquetError {
+        OpenSwathParquetError::DatabaseError(err.to_string())
+    }
+}
+
+impl From<std::io::Error> for OpenSwathParquetError {
+    fn from(err: std::io::Error) -> OpenSwathParquetError {
+        OpenSwathParquetError::IoError(err.to_string())
+    }
+}
+
+/// Represents a PyProphet split parquet directory structure
+pub struct OswpqAccess {
+    /// Path to the .oswpqd directory
+    pub base_path: PathBuf,
+}
+
+/// Feature data from precursors_features.parquet
+#[derive(Debug, Clone)]
+pub struct PrecursorFeature {
+    pub protein_id: Option<i64>,
+    pub peptide_id: Option<i64>,
+    pub ipf_peptide_id: Option<i64>,
+    pub precursor_id: i64,
+    pub run_id: i64,
+    pub filename: String,
+    pub feature_id: i64,
+    pub exp_rt: f64,
+    pub left_width: f64,
+    pub right_width: f64,
+    pub feature_ms2_area_intensity: Option<f64>,
+    pub score_ms2_q_value: Option<f64>,
+    pub score_ms2_pep: Option<f64>,
+    pub precursor_decoy: Option<i64>,
+}
+
+/// Alignment feature data for writing to feature_alignment.parquet
+#[derive(Debug, Clone)]
+pub struct AlignmentFeature {
+    pub alignment_id: i64,
+    pub run_id: i64,
+    pub precursor_id: i64,
+    pub feature_id: i64,
+    pub reference_feature_id: i64,
+    pub aligned_rt: f64,
+    pub reference_rt: f64,
+    pub var_xcorr_coelution_to_reference: Option<f64>,
+    pub var_xcorr_shape_to_reference: Option<f64>,
+    pub var_mi_to_reference: Option<f64>,
+    pub var_xcorr_coelution_to_all: Option<f64>,
+    pub var_xcorr_shape: Option<f64>,
+    pub var_mi_to_all: Option<f64>,
+    pub var_retention_time_deviation: Option<f64>,
+    pub var_peak_intensity_ratio: Option<f64>,
+    pub decoy: i64,
+}
+
+impl OswpqAccess {
+    /// Create a new OswpqAccess instance
+    ///
+    /// # Arguments
+    /// * `base_path` - Path to the .oswpqd directory
+    pub fn new<P: AsRef<Path>>(base_path: P) -> Result<Self, OpenSwathParquetError> {
+        let base_path = base_path.as_ref().to_path_buf();
+        
+        // Verify the path exists and is a directory
+        if !base_path.exists() {
+            return Err(OpenSwathParquetError::FileNotFound(
+                base_path.display().to_string(),
+            ));
+        }
+        
+        if !base_path.is_dir() {
+            return Err(OpenSwathParquetError::InvalidFormat(
+                "OSWPQD path must be a directory".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            base_path,
+        })
+    }
+
+    /// Create a DuckDB connection for querying
+    fn create_connection(&self) -> Result<Connection, OpenSwathParquetError> {
+        Connection::open_in_memory()
+            .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))
+    }
+
+    /// List all run directories (.oswpq) in the base directory
+    pub fn list_runs(&self) -> Result<Vec<String>, OpenSwathParquetError> {
+        let mut runs = Vec::new();
+        
+        let entries = fs::read_dir(&self.base_path)
+            .map_err(|e| OpenSwathParquetError::IoError(e.to_string()))?;
+
+        for entry in entries {
+            let entry = entry.map_err(|e| OpenSwathParquetError::IoError(e.to_string()))?;
+            let path = entry.path();
+            
+            if path.is_dir() {
+                if let Some(name) = path.file_name() {
+                    let name_str = name.to_string_lossy().to_string();
+                    if name_str.ends_with(".oswpq") {
+                        runs.push(name_str);
+                    }
+                }
+            }
+        }
+
+        Ok(runs)
+    }
+
+    /// Get the path to a specific run's precursors_features.parquet file
+    pub fn get_precursors_features_path(&self, run_name: &str) -> PathBuf {
+        self.base_path
+            .join(run_name)
+            .join("precursors_features.parquet")
+    }
+
+    /// Get the path to a specific run's transition_features.parquet file
+    pub fn get_transition_features_path(&self, run_name: &str) -> PathBuf {
+        self.base_path
+            .join(run_name)
+            .join("transition_features.parquet")
+    }
+
+    /// Fetch precursor features for a specific precursor ID across all runs
+    pub fn fetch_precursor_features_for_runs(
+        &self,
+        precursor_id: i32,
+        runs: Vec<String>,
+    ) -> Result<Vec<PrecursorFeature>, OpenSwathParquetError> {
+        let mut all_features = Vec::new();
+        let conn = self.create_connection()?;
+
+        for run_name in runs {
+            let precursor_path = self.get_precursors_features_path(&run_name);
+            
+            if !precursor_path.exists() {
+                log::warn!(
+                    "Precursors features file not found for run {}: {}",
+                    run_name,
+                    precursor_path.display()
+                );
+                continue;
+            }
+
+            let query = format!(
+                r#"
+                SELECT 
+                    PROTEIN_ID,
+                    PEPTIDE_ID,
+                    IPF_PEPTIDE_ID,
+                    PRECURSOR_ID,
+                    RUN_ID,
+                    FILENAME,
+                    FEATURE_ID,
+                    EXP_RT,
+                    LEFT_WIDTH,
+                    RIGHT_WIDTH,
+                    FEATURE_MS2_AREA_INTENSITY,
+                    SCORE_MS2_Q_VALUE,
+                    SCORE_MS2_PEP,
+                    PRECURSOR_DECOY
+                FROM read_parquet('{}')
+                WHERE PRECURSOR_ID = {}
+                ORDER BY EXP_RT
+                "#,
+                precursor_path.display(),
+                precursor_id
+            );
+
+            let mut stmt = conn
+                .prepare(&query)
+                .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+
+            let features: Vec<PrecursorFeature> = stmt
+                .query_map([], |row| {
+                    Ok(PrecursorFeature {
+                        protein_id: row.get(0)?,
+                        peptide_id: row.get(1)?,
+                        ipf_peptide_id: row.get(2)?,
+                        precursor_id: row.get(3)?,
+                        run_id: row.get(4)?,
+                        filename: row.get(5)?,
+                        feature_id: row.get(6)?,
+                        exp_rt: row.get(7)?,
+                        left_width: row.get(8)?,
+                        right_width: row.get(9)?,
+                        feature_ms2_area_intensity: row.get(10)?,
+                        score_ms2_q_value: row.get(11)?,
+                        score_ms2_pep: row.get(12)?,
+                        precursor_decoy: row.get(13)?,
+                    })
+                })
+                .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?
+                .collect::<DuckDbResult<Vec<_>>>()
+                .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+
+            all_features.extend(features);
+        }
+
+        Ok(all_features)
+    }
+
+    /// Fetch all unique precursor IDs from the parquet files
+    pub fn fetch_all_precursor_ids(&self) -> Result<Vec<i32>, OpenSwathParquetError> {
+        let runs = self.list_runs()?;
+        
+        if runs.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let conn = self.create_connection()?;
+
+        // Build a query that unions all precursor IDs from all runs
+        let mut union_queries = Vec::new();
+        
+        for run_name in &runs {
+            let precursor_path = self.get_precursors_features_path(run_name);
+            
+            if precursor_path.exists() {
+                union_queries.push(format!(
+                    "SELECT DISTINCT PRECURSOR_ID FROM read_parquet('{}')",
+                    precursor_path.display()
+                ));
+            }
+        }
+
+        if union_queries.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let query = format!(
+            "SELECT DISTINCT PRECURSOR_ID FROM ({}) ORDER BY PRECURSOR_ID",
+            union_queries.join(" UNION ALL ")
+        );
+
+        let mut stmt = conn
+            .prepare(&query)
+            .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+
+        let precursor_ids: Vec<i32> = stmt
+            .query_map([], |row| row.get(0))
+            .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?
+            .collect::<DuckDbResult<Vec<_>>>()
+            .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+
+        Ok(precursor_ids)
+    }
+
+    /// Write alignment features to feature_alignment.parquet
+    pub fn write_alignment_features(
+        &self,
+        features: &[AlignmentFeature],
+    ) -> Result<(), OpenSwathParquetError> {
+        if features.is_empty() {
+            log::warn!("No alignment features to write");
+            return Ok(());
+        }
+
+        let output_path = self.base_path.join("feature_alignment.parquet");
+        let conn = self.create_connection()?;
+
+        // Create a temporary table with the alignment data
+        conn
+            .execute(
+                r#"
+                CREATE TEMPORARY TABLE alignment_temp (
+                    ALIGNMENT_ID BIGINT,
+                    RUN_ID BIGINT,
+                    PRECURSOR_ID BIGINT,
+                    FEATURE_ID BIGINT,
+                    REFERENCE_FEATURE_ID BIGINT,
+                    ALIGNED_RT DOUBLE,
+                    REFERENCE_RT DOUBLE,
+                    VAR_XCORR_COELUTION_TO_REFERENCE DOUBLE,
+                    VAR_XCORR_SHAPE_TO_REFERENCE DOUBLE,
+                    VAR_MI_TO_REFERENCE DOUBLE,
+                    VAR_XCORR_COELUTION_TO_ALL DOUBLE,
+                    VAR_XCORR_SHAPE DOUBLE,
+                    VAR_MI_TO_ALL DOUBLE,
+                    VAR_RETENTION_TIME_DEVIATION DOUBLE,
+                    VAR_PEAK_INTENSITY_RATIO DOUBLE,
+                    DECOY BIGINT
+                )
+                "#,
+                [],
+            )
+            .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+
+        // Insert features in batches
+        let batch_size = 1000;
+        for chunk in features.chunks(batch_size) {
+            let mut values = Vec::new();
+            
+            for feature in chunk {
+                values.push(format!(
+                    "({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {})",
+                    feature.alignment_id,
+                    feature.run_id,
+                    feature.precursor_id,
+                    feature.feature_id,
+                    feature.reference_feature_id,
+                    feature.aligned_rt,
+                    feature.reference_rt,
+                    feature.var_xcorr_coelution_to_reference.map_or("NULL".to_string(), |v| v.to_string()),
+                    feature.var_xcorr_shape_to_reference.map_or("NULL".to_string(), |v| v.to_string()),
+                    feature.var_mi_to_reference.map_or("NULL".to_string(), |v| v.to_string()),
+                    feature.var_xcorr_coelution_to_all.map_or("NULL".to_string(), |v| v.to_string()),
+                    feature.var_xcorr_shape.map_or("NULL".to_string(), |v| v.to_string()),
+                    feature.var_mi_to_all.map_or("NULL".to_string(), |v| v.to_string()),
+                    feature.var_retention_time_deviation.map_or("NULL".to_string(), |v| v.to_string()),
+                    feature.var_peak_intensity_ratio.map_or("NULL".to_string(), |v| v.to_string()),
+                    feature.decoy,
+                ));
+            }
+
+            let insert_query = format!(
+                "INSERT INTO alignment_temp VALUES {}",
+                values.join(", ")
+            );
+
+            conn
+                .execute(&insert_query, [])
+                .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+        }
+
+        // Export to parquet
+        let export_query = format!(
+            "COPY alignment_temp TO '{}' (FORMAT PARQUET)",
+            output_path.display()
+        );
+
+        conn
+            .execute(&export_query, [])
+            .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+
+        log::info!(
+            "Wrote {} alignment features to {}",
+            features.len(),
+            output_path.display()
+        );
+
+        Ok(())
+    }
+
+    /// Fetch transition IDs for precursors (equivalent to OSW's fetch_transition_ids)
+    /// 
+    /// This method queries the precursors_features.parquet files to extract precursor metadata
+    /// Note: OSWPQ format doesn't have separate transition tables in the same way as OSW,
+    /// so this implementation focuses on precursor-level data.
+    pub fn fetch_transition_ids(
+        &self,
+        filter_decoys: bool,
+        _include_identifying_transitions: bool,
+        precursor_ids: Option<Vec<u32>>,
+    ) -> Result<Vec<PrecursorIdData>, OpenSwathParquetError> {
+        let runs = self.list_runs()?;
+        
+        if runs.is_empty() {
+            log::warn!("No runs found in OSWPQ directory");
+            return Ok(Vec::new());
+        }
+
+        let conn = self.create_connection()?;
+        let mut precursor_map: HashMap<i32, PrecursorIdData> = HashMap::new();
+
+        // Query each run's precursor features
+        for run_name in &runs {
+            let precursor_path = self.get_precursors_features_path(run_name);
+            
+            if !precursor_path.exists() {
+                log::warn!("Precursors features file not found for run {}", run_name);
+                continue;
+            }
+
+            // Build the query
+            let mut query = format!(
+                r#"
+                SELECT DISTINCT
+                    PRECURSOR_ID,
+                    MODIFIED_SEQUENCE,
+                    PRECURSOR_CHARGE,
+                    PRECURSOR_DECOY
+                FROM read_parquet('{}')
+                WHERE 1=1
+                "#,
+                precursor_path.display()
+            );
+
+            // Add decoy filter if needed
+            if filter_decoys {
+                query.push_str(" AND (PRECURSOR_DECOY = 0 OR PRECURSOR_DECOY IS NULL)");
+            }
+
+            // Add precursor ID filter if provided
+            if let Some(ref ids) = precursor_ids {
+                let id_list = ids.iter()
+                    .map(|id| id.to_string())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                query.push_str(&format!(" AND PRECURSOR_ID IN ({})", id_list));
+            }
+
+            let mut stmt = conn.prepare(&query)
+                .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+
+            let precursor_iter = stmt.query_map([], |row| {
+                let precursor_id: i32 = row.get(0)?;
+                let modified_sequence: String = row.get(1)?;
+                let precursor_charge: i32 = row.get(2)?;
+                let decoy: Option<i32> = row.get(3)?;
+                
+                Ok((precursor_id, modified_sequence, precursor_charge, decoy.unwrap_or(0) == 1))
+            }).map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+
+            for result in precursor_iter {
+                let (precursor_id, modified_sequence, precursor_charge, decoy) = result
+                    .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+
+                precursor_map.entry(precursor_id).or_insert_with(|| {
+                    // OSWPQ doesn't have unmodified sequence readily available
+                    let unmodified_sequence = modified_sequence.clone(); // TODO: Strip modifications
+                    PrecursorIdData::new(
+                        precursor_id,
+                        unmodified_sequence,
+                        modified_sequence,
+                        precursor_charge,
+                        decoy,
+                    )
+                });
+            }
+        }
+
+        Ok(precursor_map.into_values().collect())
+    }
+
+    /// Fetch full precursor feature data for specific runs
+    pub fn fetch_full_precursor_feature_data_for_runs(
+        &self,
+        precursor_id: i32,
+        runs: Vec<String>,
+    ) -> Result<Vec<FeatureData>, OpenSwathParquetError> {
+        let conn = self.create_connection()?;
+        let mut feature_data_map: HashMap<String, FeatureData> = HashMap::new();
+
+        for run_name in runs {
+            let precursor_path = self.get_precursors_features_path(&run_name);
+            
+            if !precursor_path.exists() {
+                log::warn!("Precursors features file not found for run {}", run_name);
+                continue;
+            }
+
+            let query = format!(
+                r#"
+                SELECT 
+                    FILENAME,
+                    RUN_ID,
+                    PRECURSOR_ID,
+                    FEATURE_ID,
+                    EXP_RT,
+                    LEFT_WIDTH,
+                    RIGHT_WIDTH,
+                    FEATURE_MS2_AREA_INTENSITY
+                FROM read_parquet('{}')
+                WHERE PRECURSOR_ID = ?
+                ORDER BY EXP_RT
+                "#,
+                precursor_path.display()
+            );
+
+            let mut stmt = conn.prepare(&query)
+                .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+
+            let feature_iter = stmt.query_map([precursor_id], |row| {
+                let filename: String = row.get(0)?;
+                let run_id: i64 = row.get(1)?;
+                let precursor_id: i32 = row.get(2)?;
+                let feature_id: i64 = row.get(3)?;
+                let exp_rt: f64 = row.get(4)?;
+                let left_width: f64 = row.get(5)?;
+                let right_width: f64 = row.get(6)?;
+                let intensity: Option<f64> = row.get(7)?;
+                
+                Ok((filename, run_id, precursor_id, feature_id, exp_rt, left_width, right_width, intensity))
+            }).map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+
+            for result in feature_iter {
+                let (filename, run_id, precursor_id, feature_id, exp_rt, left_width, right_width, intensity) = result
+                    .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+
+                let entry = feature_data_map.entry(filename.clone()).or_insert_with(|| {
+                    FeatureData::new(
+                        filename.clone(),
+                        run_id,
+                        precursor_id,
+                        Some(ValueEntryType::Multiple(vec![])),
+                        ValueEntryType::Multiple(vec![]),
+                        Some(ValueEntryType::Multiple(vec![])),
+                        Some(ValueEntryType::Multiple(vec![])),
+                        Some(ValueEntryType::Multiple(vec![])),
+                        None, // rank not available in OSWPQ
+                        None, // qvalue not readily available
+                        None, // normalized_summed_intensity
+                    )
+                });
+
+                // Push values into their respective vectors
+                if let Some(ValueEntryType::Multiple(ref mut ids)) = entry.feature_id {
+                    ids.push(feature_id);
+                }
+
+                if let ValueEntryType::Multiple(ref mut exps) = entry.exp_rt {
+                    exps.push(exp_rt);
+                }
+
+                if let Some(ValueEntryType::Multiple(ref mut widths)) = entry.left_width {
+                    widths.push(left_width);
+                }
+
+                if let Some(ValueEntryType::Multiple(ref mut widths)) = entry.right_width {
+                    widths.push(right_width);
+                }
+
+                if let Some(ValueEntryType::Multiple(ref mut intensities)) = entry.intensity {
+                    if let Some(int) = intensity {
+                        intensities.push(int);
+                    }
+                }
+            }
+        }
+
+        Ok(feature_data_map.into_values().collect())
+    }
+
+    /// Fetch feature data for a batch of precursors
+    pub fn fetch_feature_data_for_precursor_batch(
+        &self,
+        precursor_run_sets: &[(i32, Vec<String>)],
+    ) -> Result<HashMap<i32, Vec<FeatureData>>, OpenSwathParquetError> {
+        let conn = self.create_connection()?;
+        let mut result_map: HashMap<i32, Vec<FeatureData>> = HashMap::new();
+
+        // Process each precursor
+        for (precursor_id, runs) in precursor_run_sets {
+            let feature_data = self.fetch_full_precursor_feature_data_for_runs(*precursor_id, runs.clone())?;
+            result_map.insert(*precursor_id, feature_data);
+        }
+
+        Ok(result_map)
+    }
+
+    /// Create MS2 alignment table (writes to parquet file)
+    /// Note: OSWPQ format uses parquet files, so this just ensures the directory structure exists
+    pub fn create_feature_ms2_alignment_table(&self) -> Result<(), OpenSwathParquetError> {
+        // In OSWPQ format, we just need to ensure the base directory exists
+        // The actual writing happens in write methods
+        log::info!("OSWPQ: MS2 alignment will be written to parquet file");
+        Ok(())
+    }
+
+    /// Create transition alignment table (writes to parquet file)
+    pub fn create_feature_transition_alignment_table(&self) -> Result<(), OpenSwathParquetError> {
+        log::info!("OSWPQ: Transition alignment will be written to parquet file");
+        Ok(())
+    }
+
+    /// Write MS2 alignment batch to parquet file
+    pub fn write_ms2_alignment_batch(
+        &self,
+        peak_mappings: &[PeakMapping],
+    ) -> Result<(), OpenSwathParquetError> {
+        if peak_mappings.is_empty() {
+            return Ok(());
+        }
+
+        let output_path = self.base_path.join("feature_ms2_alignment.parquet");
+        let conn = self.create_connection()?;
+
+        // Create temporary table
+        conn.execute(
+            r#"
+            CREATE TEMPORARY TABLE ms2_alignment_temp (
+                ALIGNMENT_ID BIGINT,
+                PRECURSOR_ID BIGINT,
+                RUN_ID BIGINT,
+                REFERENCE_FEATURE_ID BIGINT,
+                ALIGNED_FEATURE_ID BIGINT,
+                REFERENCE_RT DOUBLE,
+                ALIGNED_RT DOUBLE,
+                REFERENCE_LEFT_WIDTH DOUBLE,
+                REFERENCE_RIGHT_WIDTH DOUBLE,
+                ALIGNED_LEFT_WIDTH DOUBLE,
+                ALIGNED_RIGHT_WIDTH DOUBLE,
+                REFERENCE_FILENAME VARCHAR,
+                ALIGNED_FILENAME VARCHAR,
+                XCORR_COELUTION_TO_REFERENCE DOUBLE,
+                XCORR_SHAPE_TO_REFERENCE DOUBLE,
+                MI_TO_REFERENCE DOUBLE,
+                XCORR_COELUTION_TO_ALL DOUBLE,
+                XCORR_SHAPE_TO_ALL DOUBLE,
+                MI_TO_ALL DOUBLE,
+                RETENTION_TIME_DEVIATION DOUBLE,
+                PEAK_INTENSITY_RATIO DOUBLE,
+                LABEL BIGINT
+            )
+            "#,
+            [],
+        ).map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+
+        // Insert data in batches
+        let batch_size = 1000;
+        for chunk in peak_mappings.chunks(batch_size) {
+            let mut values = Vec::new();
+            
+            for pm in chunk {
+                values.push(format!(
+                    "({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, '{}', '{}', {}, {}, {}, {}, {}, {}, {}, {}, {})",
+                    pm.alignment_id,
+                    pm.precursor_id,
+                    pm.run_id,
+                    pm.reference_feature_id,
+                    pm.aligned_feature_id,
+                    pm.reference_rt,
+                    pm.aligned_rt,
+                    pm.reference_left_width,
+                    pm.reference_right_width,
+                    pm.aligned_left_width,
+                    pm.aligned_right_width,
+                    pm.reference_filename.replace("'", "''"),
+                    pm.aligned_filename.replace("'", "''"),
+                    pm.xcorr_coelution_to_ref.map_or("NULL".to_string(), |v| v.to_string()),
+                    pm.xcorr_shape_to_ref.map_or("NULL".to_string(), |v| v.to_string()),
+                    pm.mi_to_ref.map_or("NULL".to_string(), |v| v.to_string()),
+                    pm.xcorr_coelution_to_all.map_or("NULL".to_string(), |v| v.to_string()),
+                    pm.xcorr_shape_to_all.map_or("NULL".to_string(), |v| v.to_string()),
+                    pm.mi_to_all.map_or("NULL".to_string(), |v| v.to_string()),
+                    pm.rt_deviation.map_or("NULL".to_string(), |v| v.to_string()),
+                    pm.intensity_ratio.map_or("NULL".to_string(), |v| v.to_string()),
+                    pm.label,
+                ));
+            }
+
+            let insert_query = format!(
+                "INSERT INTO ms2_alignment_temp VALUES {}",
+                values.join(", ")
+            );
+
+            conn.execute(&insert_query, [])
+                .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+        }
+
+        // Export to parquet (append mode if file exists)
+        let export_query = if output_path.exists() {
+            // Read existing data, union with new data, and overwrite
+            format!(
+                "COPY (SELECT * FROM read_parquet('{}') UNION ALL SELECT * FROM ms2_alignment_temp) TO '{}' (FORMAT PARQUET)",
+                output_path.display(),
+                output_path.display()
+            )
+        } else {
+            format!(
+                "COPY ms2_alignment_temp TO '{}' (FORMAT PARQUET)",
+                output_path.display()
+            )
+        };
+
+        conn.execute(&export_query, [])
+            .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+
+        log::info!(
+            "Wrote {} MS2 alignment records to {}",
+            peak_mappings.len(),
+            output_path.display()
+        );
+
+        Ok(())
+    }
+
+    /// Write transition alignment batch to parquet file
+    pub fn write_transition_alignment_batch(
+        &self,
+        transition_scores: &[AlignedTransitionScores],
+    ) -> Result<(), OpenSwathParquetError> {
+        if transition_scores.is_empty() {
+            return Ok(());
+        }
+
+        let output_path = self.base_path.join("feature_transition_alignment.parquet");
+        let conn = self.create_connection()?;
+
+        // Create temporary table
+        conn.execute(
+            r#"
+            CREATE TEMPORARY TABLE transition_alignment_temp (
+                FEATURE_ID BIGINT,
+                TRANSITION_ID BIGINT,
+                RUN_ID BIGINT,
+                ALIGNED_FILENAME VARCHAR,
+                LABEL BIGINT,
+                XCORR_COELUTION_TO_REFERENCE DOUBLE,
+                XCORR_SHAPE_TO_REFERENCE DOUBLE,
+                MI_TO_REFERENCE DOUBLE,
+                XCORR_COELUTION_TO_ALL DOUBLE,
+                XCORR_SHAPE_TO_ALL DOUBLE,
+                MI_TO_ALL DOUBLE,
+                RETENTION_TIME_DEVIATION DOUBLE,
+                PEAK_INTENSITY_RATIO DOUBLE
+            )
+            "#,
+            [],
+        ).map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+
+        // Insert data in batches
+        let batch_size = 1000;
+        for chunk in transition_scores.chunks(batch_size) {
+            let mut values = Vec::new();
+            
+            for ts in chunk {
+                values.push(format!(
+                    "({}, {}, {}, '{}', {}, {}, {}, {}, {}, {}, {}, {}, {})",
+                    ts.feature_id,
+                    ts.transition_id,
+                    ts.run_id,
+                    ts.aligned_filename.replace("'", "''"),
+                    ts.label,
+                    ts.xcorr_coelution_to_ref.map_or("NULL".to_string(), |v| v.to_string()),
+                    ts.xcorr_shape_to_ref.map_or("NULL".to_string(), |v| v.to_string()),
+                    ts.mi_to_ref.map_or("NULL".to_string(), |v| v.to_string()),
+                    ts.xcorr_coelution_to_all.map_or("NULL".to_string(), |v| v.to_string()),
+                    ts.xcorr_shape_to_all.map_or("NULL".to_string(), |v| v.to_string()),
+                    ts.mi_to_all.map_or("NULL".to_string(), |v| v.to_string()),
+                    ts.rt_deviation.map_or("NULL".to_string(), |v| v.to_string()),
+                    ts.intensity_ratio.map_or("NULL".to_string(), |v| v.to_string()),
+                ));
+            }
+
+            let insert_query = format!(
+                "INSERT INTO transition_alignment_temp VALUES {}",
+                values.join(", ")
+            );
+
+            conn.execute(&insert_query, [])
+                .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+        }
+
+        // Export to parquet (append mode if file exists)
+        let export_query = if output_path.exists() {
+            format!(
+                "COPY (SELECT * FROM read_parquet('{}') UNION ALL SELECT * FROM transition_alignment_temp) TO '{}' (FORMAT PARQUET)",
+                output_path.display(),
+                output_path.display()
+            )
+        } else {
+            format!(
+                "COPY transition_alignment_temp TO '{}' (FORMAT PARQUET)",
+                output_path.display()
+            )
+        };
+
+        conn.execute(&export_query, [])
+            .map_err(|e| OpenSwathParquetError::DatabaseError(e.to_string()))?;
+
+        log::info!(
+            "Wrote {} transition alignment records to {}",
+            transition_scores.len(),
+            output_path.display()
+        );
+
+        Ok(())
+    }
+
+    /// Get the base path of the OSWPQD directory
+    pub fn get_base_path(&self) -> &Path {
+        &self.base_path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_oswpq_access_creation() {
+        // This test would need actual test data
+        // For now, just test error handling
+        let result = OswpqAccess::new("/nonexistent/path");
+        assert!(result.is_err());
+    }
+}

--- a/crates/arycal-common/src/config.rs
+++ b/crates/arycal-common/src/config.rs
@@ -162,10 +162,10 @@ pub struct AlignmentConfig {
     pub smoothing: SmoothingConfig,
     /// Retention time mapping tolerance in seconds for mapping aligned query peak to reference peak.
     pub rt_mapping_tolerance: Option<f64>,
-    /// Method to use for mapping decoy peaks. Current options are "shuffle" and "random_region".
+    /// Method to use for mapping decoy peaks. Current options are "shuffle" and "random_regions".
     #[serde(rename = "decoy_peak_mapping_method")]
     pub decoy_peak_mapping_method: String,
-    /// Size of the window to use for the decoy peak mapping. Only used when the method is "random_region".
+    /// Size of the window to use for the decoy peak mapping. Only used when the method is "random_regions".
     pub decoy_window_size: Option<usize>,
     /// Optionally compute alignment scores for the full trace alignment and peak mapping. Default is true.
     pub compute_scores: Option<bool>,

--- a/crates/arycal-common/src/config.rs
+++ b/crates/arycal-common/src/config.rs
@@ -42,6 +42,7 @@ impl XicFileType {
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub enum FeaturesFileType {
     OSW,
+    OSWPQ,
     Unknown,
 }
 
@@ -59,6 +60,7 @@ impl<'de> Deserialize<'de> for FeaturesFileType {
         let s = String::deserialize(deserializer)?;
         match s.to_lowercase().as_str() {
             "osw" => Ok(FeaturesFileType::OSW),
+            "oswpq" | "parquet" => Ok(FeaturesFileType::OSWPQ),
             _ => Ok(FeaturesFileType::Unknown),
         }
     }
@@ -68,6 +70,7 @@ impl FeaturesFileType {
     pub fn as_str(&self) -> &str {
         match self {
             FeaturesFileType::OSW => "osw",
+            FeaturesFileType::OSWPQ => "oswpq",
             FeaturesFileType::Unknown => "Unknown",
         }
     }

--- a/crates/arycal-common/src/config.rs
+++ b/crates/arycal-common/src/config.rs
@@ -112,7 +112,14 @@ impl FeaturesConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FiltersConfig {
-    pub decoy: bool,
+    /// When false, excludes decoy precursors from alignment (only processes targets).
+    /// When true, includes both target and decoy precursors in alignment.
+    /// 
+    /// Old field name was "decoy" with inverted semantics:
+    /// - Old "decoy": true meant exclude decoys → New "include_decoys": false
+    /// - Old "decoy": false meant include decoys → New "include_decoys": true
+    #[serde(alias = "decoy")] // Support old config files, but they'll be interpreted with new semantics!
+    pub include_decoys: bool,
     pub include_identifying_transitions: Option<bool>,
     pub max_score_ms2_qvalue: Option<f64>,
     /// TSV file containing the list of precursors to filter for.
@@ -122,7 +129,7 @@ pub struct FiltersConfig {
 impl Default for FiltersConfig {
     fn default() -> Self {
         FiltersConfig {
-            decoy: true,
+            include_decoys: false, // By default, exclude decoys (only align targets)
             include_identifying_transitions: Some(false),
             max_score_ms2_qvalue: Some(1.0),
             precursor_ids: None,


### PR DESCRIPTION
This pull request adds support for the PyProphet split parquet format (`oswpqd`) to ARYCAL, enabling fully parallelized reading and alignment workflows. The changes introduce a unified feature accessor abstraction for both OSW (SQLite) and OSWPQ (parquet) formats, update documentation and configuration templates, and simplify the input configuration structure. These improvements make the tool more flexible, easier to use, and better documented for multiple data formats.

**Major feature additions:**

* Added support for PyProphet split parquet format (`oswpqd`) in both the CLI and configuration, including a parallelized reader and unified feature accessor (`FeatureAccessor`) for both OSW and OSWPQ formats. [[1]](diffhunk://#diff-850471b221477221ac32b2da53fc3834950f402a4eaf52648c1615df93f517cdR40-R154) [[2]](diffhunk://#diff-850471b221477221ac32b2da53fc3834950f402a4eaf52648c1615df93f517cdL51-R202)

* Updated input validation and configuration to support both `sqMass` and `parquet` for XIC files, and both `osw` and `oswpqd` for feature files. [[1]](diffhunk://#diff-5bc8005280a6258a1da88fa5c14a240c1c2b8cd5ffddb425edca4a682ff58c9bL145-R131) [[2]](diffhunk://#diff-5bc8005280a6258a1da88fa5c14a240c1c2b8cd5ffddb425edca4a682ff58c9bL19-L55)

**Documentation and usability improvements:**

* Expanded the `README.md` with clear documentation for multiple input formats, quick start instructions, configuration field explanations, and example configurations for both OSW and OSWPQ workflows. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24-R34) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R109-R242)

**Codebase simplification:**

* Removed unused GUI-related fields from the input configuration structure to streamline CLI usage.

* Refactored the codebase to use the new `FeatureAccessor` abstraction throughout the alignment and results writing logic, ensuring compatibility with both OSW and OSWPQ feature types. [[1]](diffhunk://#diff-850471b221477221ac32b2da53fc3834950f402a4eaf52648c1615df93f517cdL95-R236) [[2]](diffhunk://#diff-850471b221477221ac32b2da53fc3834950f402a4eaf52648c1615df93f517cdL126-R284) [[3]](diffhunk://#diff-850471b221477221ac32b2da53fc3834950f402a4eaf52648c1615df93f517cdL141-R300) [[4]](diffhunk://#diff-850471b221477221ac32b2da53fc3834950f402a4eaf52648c1615df93f517cdL1056-R1209) [[5]](diffhunk://#diff-850471b221477221ac32b2da53fc3834950f402a4eaf52648c1615df93f517cdL1069-R1227) [[6]](diffhunk://#diff-850471b221477221ac32b2da53fc3834950f402a4eaf52648c1615df93f517cdL1085-R1238)

These changes collectively improve ARYCAL's flexibility, performance, and ease of use for users working with different chromatogram alignment workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for PyProphet split-parquet (OSWPQ), sqMass and Parquet XIC inputs.
  * Automatic config template generation and Quick Start flow when no parameters provided.
  * New top-level config options: threads, log_level, compute_scores, scores_output_file, retain_alignment_path.

* **Documentation**
  * Expanded README with Quick Start, template usage, parallelization notes, and detailed Configuration Fields.

* **Improvements**
  * Stronger config validation and file-path inference; clearer config field naming (decoy → include_decoys) and updated alignment defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->